### PR TITLE
Add interactive moons viewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ TinyNetLab/
 python tinynet.py
 ```
 
+## 🖱 Interactive moons explorer
+
+To experiment with the dataset itself, run `python moons_gui.py`. A window will
+appear with sliders to control the sample size and noise level so you can see how
+these parameters affect the moons distribution in real time.
+
 Or import parts of the code into your own experiments!
 
 ## 📌 License

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -57,6 +57,10 @@ python tinynet.py
 
 或者将代码中的部分模块引入到你自己的实验中！
 
+## 🖱 交互式 Moons 数据查看器
+
+运行 `python moons_gui.py` 即可打开一个窗口，通过滑块调整样本数和噪声水平，实时观察数据分布的变化。
+
 ## 📌 许可证
 
 MIT License.

--- a/moons.py
+++ b/moons.py
@@ -1,0 +1,10 @@
+from sklearn.datasets import make_moons
+import numpy as np
+import matplotlib.pyplot as plt
+
+X, y = make_moons(n_samples=800, noise=0.2, random_state=42)
+y = y.reshape(-1, 1)  # (800,1) 方便矩阵运算
+
+plt.scatter(X[:, 0], X[:, 1], c=y[:, 0], cmap='coolwarm', s=15)
+plt.title("Moons 数据分布")
+plt.show()

--- a/moons_gui.py
+++ b/moons_gui.py
@@ -1,0 +1,39 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from matplotlib.widgets import Slider
+from sklearn.datasets import make_moons
+
+# Initial parameters
+INITIAL_SAMPLES = 800
+INITIAL_NOISE = 0.2
+
+# Generate initial dataset
+X, y = make_moons(n_samples=INITIAL_SAMPLES, noise=INITIAL_NOISE, random_state=42)
+
+fig, ax = plt.subplots()
+plt.subplots_adjust(bottom=0.25)
+scat = ax.scatter(X[:, 0], X[:, 1], c=y, cmap='coolwarm', s=15)
+ax.set_title("Moons 数据分布")
+
+# Slider for noise
+ax_noise = plt.axes([0.25, 0.1, 0.65, 0.03])
+noise_slider = Slider(ax_noise, 'noise', 0.0, 0.5, valinit=INITIAL_NOISE, valstep=0.01)
+
+# Slider for number of samples
+ax_samples = plt.axes([0.25, 0.05, 0.65, 0.03])
+samples_slider = Slider(ax_samples, 'samples', 100, 1000, valinit=INITIAL_SAMPLES, valstep=50)
+
+def update(val):
+    n_samples = int(samples_slider.val)
+    noise = noise_slider.val
+    X, y = make_moons(n_samples=n_samples, noise=noise, random_state=42)
+    scat.set_offsets(X)
+    scat.set_array(y)
+    ax.relim()
+    ax.autoscale_view()
+    fig.canvas.draw_idle()
+
+noise_slider.on_changed(update)
+samples_slider.on_changed(update)
+
+plt.show()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,16 @@
+[project]
+name = "tinynetlab"
+version = "0.1.0"
+description = "Small demo generating moons dataset"
+authors = [ { name = "TinyNetLab" } ]
+readme = "README.md"
+requires-python = ">=3.8"
+dependencies = [
+    "numpy",
+    "matplotlib",
+    "scikit-learn"
+]
+
+[build-system]
+requires = ["setuptools", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
## Summary
- add `moons_gui.py` interactive script with sliders for noise and sample count
- document interactive viewer in README and README.zh

## Testing
- `python moons_gui.py` *(shows slider warnings)*
- `python moons.py`


------
https://chatgpt.com/codex/tasks/task_e_6869a373d6a883318cd58eadfa261c17