### PR TITLE
Add UI translation support

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,8 @@ Launch the combined Streamlit interface and switch between apps:
 streamlit run app.py
 ```
 
+Use the **Language** selector in the sidebar to switch between English and Chinese UI text.
+
 ### Individual apps
 
 You can still run each demo separately:

--- a/app.py
+++ b/app.py
@@ -2,17 +2,30 @@
 import streamlit as st
 import tinynet
 import moons_streamlit
+from i18n import t
 
 APPS = {
-    "Moons Explorer": moons_streamlit.main,
-    "TinyNet Trainer": tinynet.main,
-    
+    "moons": moons_streamlit.main,
+    "tinynet": tinynet.main,
 }
 
 def main() -> None:
-    st.sidebar.title("TinyNetLab")
-    app_names = list(APPS.keys())
-    choice = st.sidebar.radio("Select App", app_names)
+    if "lang" not in st.session_state:
+        st.session_state["lang"] = "en"
+
+    st.sidebar.title(t("app_title"))
+    st.sidebar.selectbox(
+        t("language"),
+        ["en", "zh"],
+        format_func=lambda x: "English" if x == "en" else "中文",
+        key="lang",
+    )
+
+    choice = st.sidebar.radio(
+        t("select_app"),
+        list(APPS.keys()),
+        format_func=lambda x: t("moons_explorer") if x == "moons" else t("tinynet_trainer"),
+    )
     APPS[choice]()
 
 if __name__ == "__main__":

--- a/docs/README.zh.md
+++ b/docs/README.zh.md
@@ -66,6 +66,8 @@ pip install numpy matplotlib scikit-learn
 streamlit run app.py
 ```
 
+使用侧边栏的 **语言** 下拉框可以在英文和中文界面之间切换。
+
 ### 单独运行
 
 仍然可以分别启动每个示例：

--- a/i18n.py
+++ b/i18n.py
@@ -1,0 +1,63 @@
+TRANSLATIONS = {
+    'en': {
+        'app_title': 'TinyNetLab',
+        'select_app': 'Select App',
+        'language': 'Language',
+        'moons_explorer': 'Moons Explorer',
+        'tinynet_trainer': 'TinyNet Trainer',
+        'moons_title': 'Moons Visualization',
+        'samples': 'Samples',
+        'noise': 'Noise',
+        'show_linear_model': 'Show linear model',
+        'moons_dataset': 'Moons Dataset',
+        'log_reg_loss': 'Logistic Regression loss: {loss:.4f}',
+        'linear_model_note': 'A linear model can only learn a straight decision boundary and therefore cannot correctly separate the curved moons.',
+        'moons_think': '**Think**\n\n- Why can\'t a single straight line separate the two "moons"?\n- If using only a linear model such as logistic regression, roughly how low will the loss get? Try verifying your guess.\n\nHint: The linear model can only draw a straight boundary, while the moons dataset is curved, so the loss can\'t get very low.',
+        'moons_explore_page_title': 'Moons Data Explorer',
+        'moons_distribution_title': 'Moons Data Distribution',
+        'tiny_title': 'TinyNet {n_input}-{n_hidden}-{n_output}',
+        'tinynet_description': 'Train a tiny neural network on the moons dataset and view the decision boundary.',
+        'hidden_units': 'Hidden units',
+        'epochs': 'Epochs',
+        'learning_rate': 'Learning rate',
+        'train': 'Train',
+        'final_loss': 'Final loss: {loss:.4f}',
+        'decision_boundary': 'Decision Boundary',
+        'loss_over_time': 'Loss over Time',
+    },
+    'zh': {
+        'app_title': 'TinyNetLab',
+        'select_app': '选择应用',
+        'language': '语言',
+        'moons_explorer': 'Moons 数据探索',
+        'tinynet_trainer': 'TinyNet 训练器',
+        'moons_title': 'Moons 数据可视化',
+        'samples': '样本数',
+        'noise': '噪声',
+        'show_linear_model': '显示线性模型效果',
+        'moons_dataset': 'Moons 数据集',
+        'log_reg_loss': 'Logistic Regression 损失: {loss:.4f}',
+        'linear_model_note': '线性模型只能学习直线决策边界，因此无法正确分开弯曲的 moons 数据。',
+        'moons_think': '**思考**\n\n- 画出来的两条“月牙”为什么一条直线分不开？\n- 如果只有线性模型（如 logistic regression），损失大概会降到哪？也可以试试验证你的猜想。\n\n提示：线性模型只能画出直线决策边界，而 moons 数据集呈现弯曲月牙形状，因此线性模型无法获得很低的损失。',
+        'moons_explore_page_title': 'Moons 数据探索',
+        'moons_distribution_title': 'Moons 数据分布',
+        'tiny_title': 'TinyNet {n_input}-{n_hidden}-{n_output}',
+        'tinynet_description': '训练一个小型神经网络并查看决策边界。',
+        'hidden_units': '隐藏单元数',
+        'epochs': '训练轮数',
+        'learning_rate': '学习率',
+        'train': '开始训练',
+        'final_loss': '最终损失: {loss:.4f}',
+        'decision_boundary': '决策边界',
+        'loss_over_time': '损失曲线',
+    }
+}
+
+import streamlit as st
+
+
+def t(key: str, **kwargs) -> str:
+    """Return the translated string based on current language."""
+    lang = st.session_state.get("lang", "en")
+    template = TRANSLATIONS.get(lang, TRANSLATIONS['en']).get(key, key)
+    return template.format(**kwargs)

--- a/moons_app.py
+++ b/moons_app.py
@@ -1,23 +1,18 @@
 import streamlit as st
 import matplotlib.pyplot as plt
 from sklearn.datasets import make_moons
+from i18n import t
 
 
 def main() -> None:
-    st.set_page_config(page_title="Moons 数据探索", page_icon="🌙")
+    st.set_page_config(page_title=t("moons_explore_page_title"), page_icon="🌙")
 
-    st.title("Moons 数据分布")
+    st.title(t("moons_distribution_title"))
 
-    st.markdown(
-        """
-### 思考
-1. 画出来的两条“月牙”为什么一条直线分不开？
-2. 如果只有线性模型（如 logistic regression），损失大概会降到哪？也可以试试验证你的猜想。
-"""
-    )
+    st.markdown(t("moons_think"))
 
-    samples = st.slider("样本数", min_value=100, max_value=1000, value=800, step=50)
-    noise = st.slider("噪声", min_value=0.0, max_value=0.5, value=0.2, step=0.01)
+    samples = st.slider(t("samples"), min_value=100, max_value=1000, value=800, step=50)
+    noise = st.slider(t("noise"), min_value=0.0, max_value=0.5, value=0.2, step=0.01)
 
     X, y = make_moons(n_samples=samples, noise=noise, random_state=42)
 
@@ -25,7 +20,7 @@ def main() -> None:
     ax.scatter(X[:, 0], X[:, 1], c=y, cmap="coolwarm", s=15)
     ax.set_xlabel("x1")
     ax.set_ylabel("x2")
-    ax.set_title("Moons 数据分布")
+    ax.set_title(t("moons_distribution_title"))
 
     st.pyplot(fig)
 

--- a/moons_streamlit.py
+++ b/moons_streamlit.py
@@ -5,14 +5,15 @@ import numpy as np
 from sklearn.datasets import make_moons
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import log_loss
+from i18n import t
 
 
 def main() -> None:
-    st.set_page_config(page_title="Moons Explorer")
-    st.title("Moons 数据可视化")
+    st.set_page_config(page_title=t("moons_explore_page_title"))
+    st.title(t("moons_title"))
 
-    samples = st.slider("样本数", min_value=100, max_value=1000, value=800, step=50)
-    noise = st.slider("噪声", min_value=0.0, max_value=0.5, value=0.2, step=0.01)
+    samples = st.slider(t("samples"), min_value=100, max_value=1000, value=800, step=50)
+    noise = st.slider(t("noise"), min_value=0.0, max_value=0.5, value=0.2, step=0.01)
 
     X, y = make_moons(n_samples=samples, noise=noise, random_state=42)
 
@@ -32,10 +33,10 @@ def main() -> None:
     ).properties(
         width=600,
         height=400,
-        title='Moons 数据集'
+        title=t('moons_dataset')
     )
 
-    show_lr = st.checkbox("显示线性模型效果")
+    show_lr = st.checkbox(t("show_linear_model"))
 
     if show_lr:
         model = LogisticRegression(max_iter=200)
@@ -52,21 +53,12 @@ def main() -> None:
         line = alt.Chart(boundary_df).mark_line(color='black').encode(x='x1', y='x2')
 
         st.altair_chart(chart + line, use_container_width=True)
-        st.write(f"Logistic Regression 损失: {loss:.4f}")
-        st.markdown("线性模型只能学习直线决策边界，因此无法正确分开弯曲的 moons 数据。")
+        st.write(t("log_reg_loss", loss=loss))
+        st.markdown(t("linear_model_note"))
     else:
         st.altair_chart(chart, use_container_width=True)
 
-    st.markdown(
-        """
-**思考**
-
-- 画出来的两条“月牙”为什么一条直线分不开？
-- 如果只有线性模型（如 logistic regression），损失大概会降到哪？也可以试试验证你的猜想。
-
-提示：线性模型只能画出直线决策边界，而 moons 数据集呈现弯曲月牙形状，因此线性模型无法获得很低的损失。
-"""
-    )
+    st.markdown(t("moons_think"))
 
 
 if __name__ == "__main__":

--- a/tinynet.py
+++ b/tinynet.py
@@ -8,6 +8,7 @@ import altair as alt
 # Allow large decision boundary grids
 alt.data_transformers.disable_max_rows()
 import streamlit as st
+from i18n import t
 from sklearn.datasets import make_moons
 from streamlit.delta_generator import DeltaGenerator
 
@@ -172,7 +173,7 @@ def decision_boundary_chart(df_grid: pd.DataFrame, df_data: pd.DataFrame) -> alt
         )
     )
 
-    return (boundary + points).properties(width=600, height=400, title="Decision Boundary")
+    return (boundary + points).properties(width=600, height=400, title=t("decision_boundary"))
 
 
 def loss_chart(loss_history: list[float]) -> alt.Chart:
@@ -183,7 +184,7 @@ def loss_chart(loss_history: list[float]) -> alt.Chart:
         alt.Chart(df_loss)
         .mark_line()
         .encode(x="epoch", y="loss")
-        .properties(width=600, height=300, title="Loss over Time")
+        .properties(width=600, height=300, title=t("loss_over_time"))
     )
 
 
@@ -191,23 +192,21 @@ def main() -> None:
     """Streamlit UI for training and visualizing the tiny network."""
 
     global n_hidden
-    st.set_page_config(page_title="TinyNet Trainer")
+    st.set_page_config(page_title=t("tinynet_trainer"))
     title = st.empty()
     
-    n_hidden = st.slider("Hidden units", 1, 64, n_hidden, step=1)
+    n_hidden = st.slider(t("hidden_units"), 1, 64, n_hidden, step=1)
     with title.container():
-        st.title(f"TinyNet {n_input}-{n_hidden}-{n_output}")
+        st.title(t("tiny_title", n_input=n_input, n_hidden=n_hidden, n_output=n_output))
         
-    st.markdown(
-        "Train a tiny neural network on the moons dataset and view the decision boundary."
-    )
+    st.markdown(t("tinynet_description"))
 
-    samples = st.slider("Samples", 100, 1000, 800, step=50)
-    noise = st.slider("Noise", 0.0, 0.5, 0.2, step=0.01)
-    epochs = st.slider("Epochs", 5000, 200000, 50000, step=100)
-    lr = st.slider("Learning rate", 0.01, 1.0, 0.1, step=0.01)
+    samples = st.slider(t("samples"), 100, 1000, 800, step=50)
+    noise = st.slider(t("noise"), 0.0, 0.5, 0.2, step=0.01)
+    epochs = st.slider(t("epochs"), 5000, 200000, 50000, step=100)
+    lr = st.slider(t("learning_rate"), 0.01, 1.0, 0.1, step=0.01)
 
-    if st.button("Train"):
+    if st.button(t("train")):
         X, y = make_moons(n_samples=samples, noise=noise, random_state=42)
         y = y.reshape(-1, 1)
 
@@ -225,7 +224,7 @@ def main() -> None:
             loss_chart_placeholder=loss_chart_placeholder,
         )
 
-        st.write(f"Final loss: {loss:.4f}")
+        st.write(t("final_loss", loss=loss))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add translation dictionary and helper `t()`
- let apps switch language via sidebar dropdown
- localize all UI text strings
- document language switching in README files

## Testing
- `python -m py_compile app.py tinynet.py moons_streamlit.py moons_app.py i18n.py`

------
https://chatgpt.com/codex/tasks/task_e_686d7be78fc8833194eb3dd27d0d6388