### PR TITLE
Add test for translation key consistency

### DIFF
--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,0 +1,14 @@
+import os
+import sys
+import types
+
+# Ensure repository root is on sys.path
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+# Provide a minimal stub for streamlit to satisfy imports
+sys.modules.setdefault("streamlit", types.ModuleType("streamlit"))
+
+from i18n import TRANSLATIONS
+
+
+def test_translation_keys_match():
+    assert set(TRANSLATIONS["en"]) == set(TRANSLATIONS["zh"])


### PR DESCRIPTION
## Summary
- add a minimal test to ensure English and Chinese translations share the same keys

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686d7ea2b26083318b69026be8f2d210