### PR TITLE
Add positional encoding visualization

### DIFF
--- a/i18n.py
+++ b/i18n.py
@@ -31,6 +31,9 @@ TRANSLATIONS = {
         'show_attention_matrix': 'Show attention matrix',
         'attention_matrix': 'Attention Matrix',
         'vector_transform': 'Vector transform',
+        'use_positional_encoding': 'Use positional encoding',
+        'show_positional_encoding': 'Show positional encoding',
+        'positional_encoding': 'Positional Encoding',
     },
     'zh': {
         'app_title': 'TinyNetLab',
@@ -64,6 +67,9 @@ TRANSLATIONS = {
         'show_attention_matrix': '显示注意力矩阵',
         'attention_matrix': '注意力矩阵',
         'vector_transform': '向量变化',
+        'use_positional_encoding': '使用位置编码',
+        'show_positional_encoding': '显示位置编码',
+        'positional_encoding': '位置编码',
     }
 }
 

--- a/tests/test_positional_encoding.py
+++ b/tests/test_positional_encoding.py
@@ -1,0 +1,19 @@
+import numpy as np
+import sys
+import os
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from attention_demo import sinusoidal_positional_encoding
+
+
+def test_sinusoidal_positional_encoding_shape_and_values():
+    length, dim = 3, 4
+    pe = sinusoidal_positional_encoding(length, dim)
+    assert pe.shape == (length, dim)
+    # Position 0 should be all zeros except cos terms which are 1
+    assert np.allclose(pe[0, 0], 0.0)
+    assert np.allclose(pe[0, 1], 1.0)
+    if dim > 2:
+        assert np.allclose(pe[0, 2], 0.0)
+        assert np.allclose(pe[0, 3], 1.0)


### PR DESCRIPTION
## Summary
- implement sinusoidal positional encoding and visualization
- expose positional encoding options in attention demo
- translate new UI text
- test sinusoidal positional encoding

## Testing
- `pip install numpy matplotlib scikit-learn streamlit altair pytest`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687407adc1f483318f605803c239d14f